### PR TITLE
load goal information client side

### DIFF
--- a/components/GoalTracker.tsx
+++ b/components/GoalTracker.tsx
@@ -7,9 +7,14 @@ function pct(val: number): number {
 export default function Location({ percent }: { percent: number }) {
   return (
     <react.Fragment>
-      <p className="mono">{pct(percent)}% of goal</p>
+      {percent !== undefined &&
+        <p className="mono">{pct(percent)}% of goal</p>
+      }
+      {percent === undefined &&
+        <p className="mono">Loading goal tracker...</p>
+      }
       <div style={{ width: '100%', height: 10, backgroundColor: '#ededed', position: 'relative' }}>
-        <div className="color-light-green-bg" style={{ position: 'absolute', width: `${pct(percent)}%`, height: '100%' }}></div>
+        <div className="color-light-green-bg loading-bar" style={{ position: 'absolute', width: `${pct(percent)}%`, height: '100%' }}></div>
       </div>
     </react.Fragment>
   );


### PR DESCRIPTION
Loads goal information client side instead of on server side to allow the page to render initially, then update with goal information once it is available. Otherwise you're left with an awkward pause when clicking the "registry" nav item and the page waits for server-side props to load before rendering.

Practically, this creates a new route `GET /api/registry` which returns an object like this: 

```js
{
  data: {
    HOUSE: "number",
    HONEYMOON: "number",
    PAWS: "number"
  }
}
```

![tksm-goal-tracker-loading](https://user-images.githubusercontent.com/1943001/228114675-4dff74d6-42dd-4e99-b6f1-cd9c9d9c6390.gif)
